### PR TITLE
US 3.1 — Filtres al Catàleg (frontend)

### DIFF
--- a/backend/src/routes/game.routes.js
+++ b/backend/src/routes/game.routes.js
@@ -4,11 +4,120 @@ import { Game } from '../models/Game.js';
 
 const router = Router();
 
-/** GET /api/games -> todos los juegos */
+/** GET /api/games -> listado con filtros, ordenación y paginación */
 router.get('/', async (req, res, next) => {
   try {
-    const games = await Game.find().lean();
-    res.json(games);
+    const parseArrayParam = (value) => {
+      if (!value) return [];
+      if (Array.isArray(value)) return value.filter(Boolean);
+      return String(value)
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean);
+    };
+
+    const page = Math.max(parseInt(req.query.page ?? '1', 10) || 1, 1);
+    const limitRaw = parseInt(req.query.limit ?? '12', 10) || 12;
+    const limit = Math.min(Math.max(limitRaw, 1), 50);
+    const skip = (page - 1) * limit;
+    const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    const genres = parseArrayParam(req.query.genres);
+    const platforms = parseArrayParam(req.query.platforms);
+
+    const filters = {};
+
+    if (q) {
+      const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const regex = new RegExp(escaped, 'i');
+      filters.$or = [
+        { name: regex },
+        { genre: regex },
+        { platform: regex }
+      ];
+    }
+
+    if (genres.length) filters.genre = { $in: genres };
+    if (platforms.length) filters.platform = { $in: platforms };
+
+    const sortKey = typeof req.query.sort === 'string' ? req.query.sort : 'best';
+    const sortMap = {
+      best:    { averageRating: -1, reviewCount: -1, year: -1 },
+      worst:   { averageRating: 1, reviewCount: 1, year: -1 },
+      year:    { year: -1, averageRating: -1 },
+      reviews: { reviewCount: -1, averageRating: -1, year: -1 }
+    };
+    const selectedSort = sortMap[sortKey] || sortMap.best;
+
+    const ratingFieldsStage = {
+      $addFields: {
+        reviewCount: { $size: '$reviews' },
+        averageRating: {
+          $round: [
+            {
+              $cond: [
+                { $gt: [{ $size: '$reviews' }, 0] },
+                {
+                  $divide: [
+                    {
+                      $reduce: {
+                        input: '$reviews',
+                        initialValue: 0,
+                        in: { $add: ['$$value', { $ifNull: ['$$this.stars', 0] }] }
+                      }
+                    },
+                    { $size: '$reviews' }
+                  ]
+                },
+                0
+              ]
+            },
+            2
+          ]
+        }
+      }
+    };
+
+    const [totalItems, items, rawGenres, rawPlatforms] = await Promise.all([
+      Game.countDocuments(filters),
+      Game.aggregate([
+        { $match: filters },
+        ratingFieldsStage,
+        { $sort: selectedSort },
+        { $skip: skip },
+        { $limit: limit },
+        {
+          $project: {
+            name: 1,
+            genre: 1,
+            platform: 1,
+            year: 1,
+            image: 1,
+            averageRating: 1,
+            reviewCount: 1
+          }
+        }
+      ]),
+      Game.distinct('genre'),
+      Game.distinct('platform')
+    ]);
+
+    const sanitizeList = (list) =>
+      list
+        .filter((item) => typeof item === 'string' && item.trim().length)
+        .map((item) => item.trim())
+        .sort((a, b) => a.localeCompare(b));
+
+    const totalPages = totalItems === 0 ? 0 : Math.ceil(totalItems / limit);
+
+    res.json({
+      items,
+      page,
+      pageSize: limit,
+      totalItems,
+      totalPages,
+      availableGenres: sanitizeList(rawGenres),
+      availablePlatforms: sanitizeList(rawPlatforms)
+    });
   } catch (err) {
     next(err);
   }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -22,6 +22,9 @@ app.use(helmet());
 const allowedOrigins = [
   'https://calm-forest-0e7ca3203.3.azurestaticapps.net', 
   'https://witty-bay-0f8f41603.3.azurestaticapps.net', 
+  'http://localhost:3000',
+  'http://localhost:5173',
+  'http://localhost:4000',
   env.corsOrigin                                    
 ];
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -53,6 +53,51 @@ export type Game = {
   reviews: Review[];
 };
 
+export type GameSummary = {
+  _id: string;
+  name: string;
+  genre: string;
+  year: number;
+  platform: string;
+  image: string;
+  averageRating: number;
+  reviewCount: number;
+};
+
+export type PaginatedGamesResponse = {
+  items: GameSummary[];
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+  availableGenres: string[];
+  availablePlatforms: string[];
+};
+
+type GameQueryParams = Partial<{
+  q: string;
+  sort: string;
+  page: number;
+  limit: number;
+  genres: string[];
+  platforms: string[];
+}>;
+
+const buildQueryString = (params?: GameQueryParams) => {
+  if (!params) return '';
+  const query = new URLSearchParams();
+
+  if (params.q) query.set('q', params.q);
+  if (params.sort) query.set('sort', params.sort);
+  if (typeof params.page === 'number') query.set('page', String(params.page));
+  if (typeof params.limit === 'number') query.set('limit', String(params.limit));
+  if (params.genres && params.genres.length) query.set('genres', params.genres.join(','));
+  if (params.platforms && params.platforms.length) query.set('platforms', params.platforms.join(','));
+
+  const qs = query.toString();
+  return qs ? `?${qs}` : '';
+};
+
 async function http<T>(path: string, opts?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     headers: { "Content-Type": "application/json", ...(opts?.headers || {}) },
@@ -113,6 +158,7 @@ export const api = {
     }),
 
   // Jocs
-  getGames: () => http<Game[]>("/api/games"),
+  getGames: (params?: GameQueryParams) =>
+    http<PaginatedGamesResponse>(`/api/games${buildQueryString(params)}`),
   getGame:  (id: string) => http<Game>(`/api/games/${id}`),
 };

--- a/frontend/src/tests/CatalegJocs.spec.ts
+++ b/frontend/src/tests/CatalegJocs.spec.ts
@@ -3,9 +3,8 @@ import { mount, flushPromises } from '@vue/test-utils';
 import CatalegJocs from '../views/CatalegJocs.vue';
 import GameCardMini from '../views/GameCardMini.vue';
 import { createRouter, createWebHistory } from 'vue-router';
-import { api } from '@/services/api';
+import { api, PaginatedGamesResponse, GameSummary } from '@/services/api';
 import { auth } from '@/services/auth';
-import { Game, Review } from '@/services/api'; // Import Game and Review types
 
 // Mock de los servicios
 vi.mock('@/services/api');
@@ -24,10 +23,21 @@ const router = createRouter({
 });
 
 // Datos de prueba
-const mockGames: Game[] = [ // Typed as Game[]
-  { _id: '1', name: 'The Witcher 3', genre: 'RPG', year: 2015, platform: 'PC', image: 'tw3.jpg', reviews: [] }, // Added reviews
-  { _id: '2', name: 'Red Dead Redemption 2', genre: 'Action', year: 2018, platform: 'PS4', image: 'rdr2.jpg', reviews: [] }, // Added reviews
+const mockGames: GameSummary[] = [
+  { _id: '1', name: 'The Witcher 3', genre: 'RPG', year: 2015, platform: 'PC', image: 'tw3.jpg', averageRating: 4.8, reviewCount: 120 },
+  { _id: '2', name: 'Red Dead Redemption 2', genre: 'Action', year: 2018, platform: 'PS4', image: 'rdr2.jpg', averageRating: 4.9, reviewCount: 200 },
 ];
+
+const createResponse = (overrides?: Partial<PaginatedGamesResponse>): PaginatedGamesResponse => ({
+  items: mockGames,
+  page: 1,
+  pageSize: 12,
+  totalItems: mockGames.length,
+  totalPages: 1,
+  availableGenres: ['RPG', 'Action'],
+  availablePlatforms: ['PC', 'PS4'],
+  ...overrides,
+});
 
 describe('CatalegJocs.vue', () => {
   beforeEach(() => {
@@ -54,7 +64,7 @@ describe('CatalegJocs.vue', () => {
 
     it('debería renderizar una lista de juegos cuando la API devuelve datos', async () => {
       // Mockeamos la API para que devuelva nuestros juegos de prueba
-      vi.mocked(api.getGames).mockResolvedValue(mockGames);
+      vi.mocked(api.getGames).mockResolvedValue(createResponse());
 
       const wrapper = mount(CatalegJocs, {
         global: {
@@ -75,12 +85,13 @@ describe('CatalegJocs.vue', () => {
       // Comprobamos que las props se pasan correctamente al primer GameCardMini
       expect(gameCards[0].props('name')).toBe('The Witcher 3');
       expect(gameCards[0].props('genre')).toBe('RPG');
+      expect(gameCards[0].props('reviewCount')).toBe(120);
     });
   });
 
   describe('Estados Especiales', () => {
     it('debería mostrar un mensaje de "No s\'han trobat jocs" si la API devuelve una lista vacía', async () => {
-      vi.mocked(api.getGames).mockResolvedValue([]); // API devuelve array vacío
+      vi.mocked(api.getGames).mockResolvedValue(createResponse({ items: [], totalItems: 0, totalPages: 0 }));
 
       const wrapper = mount(CatalegJocs, {
         global: {
@@ -97,7 +108,7 @@ describe('CatalegJocs.vue', () => {
     it('debería registrar un error en la consola si la llamada a la API falla', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {}); // Espiamos console.error
       const errorMessage = 'Error al cargar los juegos';
-      vi.mocked(api.getGames).mockRejectedValue(new Error(errorMessage)); // API falla
+      vi.mocked(api.getGames).mockRejectedValue(new Error(errorMessage));
 
       mount(CatalegJocs, {
         global: {

--- a/frontend/src/views/CatalegJocs.vue
+++ b/frontend/src/views/CatalegJocs.vue
@@ -1,10 +1,8 @@
 <template>
   <div class="min-h-screen bg-gradient-to-b from-gray-900 via-gray-950 to-black text-white">
-    <!-- Header / Navigation -->
     <header class="sticky top-0 z-50 bg-gray-900/95 backdrop-blur-md border-b border-gray-800 shadow-lg">
       <div class="w-full px-6 py-4">
         <div class="grid grid-cols-3 items-center gap-4">
-          <!-- IZQUIERDA: Logo y navegación -->
           <div class="flex items-center gap-6">
             <router-link to="/cataleg" class="flex items-center gap-2">
               <div class="w-8 h-8 flex items-center justify-center">
@@ -12,7 +10,7 @@
               </div>
               <span class="font-bold text-xl hidden sm:block">CheckPoint</span>
             </router-link>
-            
+
             <nav class="hidden lg:flex items-center gap-6">
               <button class="flex items-center gap-2 text-gray-300 hover:text-white transition-colors font-medium whitespace-nowrap">
                 <span class="text-sm">👥</span> Comunitat
@@ -23,16 +21,44 @@
             </nav>
           </div>
 
-          <!-- CENTRO: Buscador -->
           <div class="relative">
-            <div class="relative max-w-lg mx-auto">
-              <span class="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 text-lg">🔍</span>
-              <input type="text" placeholder="Buscar jocs..." v-model="searchQuery" @input="handleSearch" @focus="showSearchDropdown = searchQuery.length > 0" @blur="hideDropdown" class="w-full bg-gray-800 border border-gray-700 rounded-full pl-12 pr-5 py-3 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all hover:bg-gray-750" />
+            <div class="relative max-w-lg mx-auto flex items-center gap-3">
+              <div class="relative flex-1">
+                <span class="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 text-lg">🔍</span>
+                <input
+                  type="text"
+                  placeholder="Buscar jocs..."
+                  v-model="searchQuery"
+                  @input="handleSearch"
+                  @focus="showSearchDropdown = searchQuery.trim().length > 0"
+                  @blur="hideDropdown"
+                  @keyup.enter.prevent="handleSearchSubmit"
+                  class="w-full bg-gray-800 border border-gray-700 rounded-full pl-12 pr-5 py-3 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all hover:bg-gray-750"
+                />
+              </div>
+              <button
+                type="button"
+                class="w-11 h-11 rounded-full bg-gray-800 border border-gray-700 hover:bg-gray-700 flex items-center justify-center transition-colors"
+                aria-label="Obrir filtres"
+                @click="filterPanelOpen = true"
+              >
+                <svg viewBox="0 0 24 24" class="w-5 h-5 text-purple-300" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M3 4h18L14 12v6l-4-2v-4L3 4z"/>
+                </svg>
+              </button>
             </div>
 
-            <!-- Dropdown de búsqueda -->
-            <div v-if="showSearchDropdown && filteredGames.length > 0" class="absolute top-full left-1/2 -translate-x-1/2 w-full max-w-lg mt-2 bg-gray-800 border border-gray-700 rounded-lg shadow-2xl max-h-96 overflow-y-auto z-50">
-              <router-link v-for="game in filteredGames" :key="game.id" :to="`/game/${game.id}`" class="flex items-center gap-3 p-3 hover:bg-gray-700 cursor-pointer transition-colors" @click="closeDropdown">
+            <div
+              v-if="showSearchDropdown && searchResults.length > 0"
+              class="absolute top-full left-1/2 -translate-x-1/2 w-full max-w-lg mt-2 bg-gray-800 border border-gray-700 rounded-lg shadow-2xl max-h-96 overflow-y-auto z-50"
+            >
+              <router-link
+                v-for="game in searchResults"
+                :key="game.id"
+                :to="`/game/${game.id}`"
+                class="flex items-center gap-3 p-3 hover:bg-gray-700 cursor-pointer transition-colors"
+                @click="closeDropdown"
+              >
                 <img :src="game.image" :alt="game.name" class="w-12 h-16 object-cover rounded" />
                 <div class="flex-1">
                   <p class="font-semibold text-white">{{ game.name }}</p>
@@ -41,42 +67,61 @@
               </router-link>
             </div>
 
-            <!-- Mensaje cuando no hay resultados -->
-            <div v-if="showSearchDropdown && searchQuery && filteredGames.length === 0" class="absolute top-full left-1/2 -translate-x-1/2 w-full max-w-lg mt-2 bg-gray-800 border border-gray-700 rounded-lg shadow-2xl p-4 text-center text-gray-400 z-50">
+            <div
+              v-if="showSearchDropdown && searchQuery && searchResults.length === 0"
+              class="absolute top-full left-1/2 -translate-x-1/2 w-full max-w-lg mt-2 bg-gray-800 border border-gray-700 rounded-lg shadow-2xl p-4 text-center text-gray-400 z-50"
+            >
               No s'han trobat jocs.
             </div>
           </div>
 
-          <!-- DERECHA: User actions -->
           <div class="flex items-center justify-end gap-4">
-            <!-- ⭐ AVATAR DEL USUARIO -->
-            <router-link v-if="isLoggedIn" to="/perfil" class="w-10 h-10 rounded-full bg-gray-800 hover:bg-gray-700 flex items-center justify-center transition-colors overflow-hidden border-2 border-gray-700 hover:border-purple-500" title="Veure perfil">
-              <!-- Mostrar imagen si existe -->
+            <router-link
+              v-if="isLoggedIn"
+              to="/perfil"
+              class="w-10 h-10 rounded-full bg-gray-800 hover:bg-gray-700 flex items-center justify-center transition-colors overflow-hidden border-2 border-gray-700 hover:border-purple-500"
+              title="Veure perfil"
+            >
               <img v-if="userAvatar" :src="userAvatar" :alt="userName" class="w-full h-full object-cover" />
-              <!-- Mostrar iniciales si no hay imagen -->
               <span v-else class="text-sm font-bold">{{ userInitials }}</span>
             </router-link>
 
-            <!-- Si no está autenticado -->
-            <router-link v-else to="/login" class="w-10 h-10 rounded-full bg-gray-800 hover:bg-gray-700 flex items-center justify-center transition-colors" title="Iniciar sessió">
+            <router-link
+              v-else
+              to="/login"
+              class="w-10 h-10 rounded-full bg-gray-800 hover:bg-gray-700 flex items-center justify-center transition-colors"
+              title="Iniciar sessió"
+            >
               <span class="text-xl">👤</span>
             </router-link>
 
-            <!-- Botón de configuración / logout -->
             <div class="relative" ref="menuRef">
               <button @click="showMenu = !showMenu" class="w-10 h-10 rounded-full bg-gray-800 hover:bg-gray-700 flex items-center justify-center transition-colors">
                 <span class="text-xl">⚙️</span>
               </button>
 
-              <!-- Dropdown menu -->
               <div v-if="showMenu" class="absolute right-0 mt-2 w-48 bg-gray-800 border border-gray-700 rounded-lg shadow-2xl py-2 z-50">
-                <router-link v-if="isLoggedIn" to="/perfil" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors" @click="showMenu = false">
+                <router-link
+                  v-if="isLoggedIn"
+                  to="/perfil"
+                  class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors"
+                  @click="showMenu = false"
+                >
                   📝 Editar perfil
                 </router-link>
-                <button v-if="isLoggedIn" @click="handleLogout" class="w-full text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors">
+                <button
+                  v-if="isLoggedIn"
+                  @click="handleLogout"
+                  class="w-full text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors"
+                >
                   🚪 Tancar sessió
                 </button>
-                <router-link v-else to="/login" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors" @click="showMenu = false">
+                <router-link
+                  v-else
+                  to="/login"
+                  class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors"
+                  @click="showMenu = false"
+                >
                   🔑 Iniciar sessió
                 </router-link>
               </div>
@@ -86,7 +131,6 @@
       </div>
     </header>
 
-    <!-- Hero Section -->
     <div class="relative h-[280px] md:h-[320px] overflow-hidden">
       <img src="../assets/background_image.jpg" alt="Hero" class="w-full h-full object-cover object-center scale-105" style="object-position: center 60%;" />
       <div class="absolute inset-0 bg-gradient-to-b from-gray-900/70 via-gray-900/50 to-gray-900" />
@@ -100,30 +144,61 @@
       <div class="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-transparent via-purple-500/50 to-transparent" />
     </div>
 
-    <!-- Catàleg de jocs -->
     <div class="max-w-7xl mx-auto px-4 py-12">
       <div class="mb-8">
         <h2 class="text-3xl font-bold mb-2">Jocs Destacats</h2>
         <p class="text-gray-400">Explora la nostra selecció de títols populars</p>
       </div>
 
-      <!-- Loading state -->
+      <div class="mb-6">
+        <div v-if="activeFilters.length" class="flex flex-wrap gap-2">
+          <button
+            v-for="filter in activeFilters"
+            :key="`${filter.type}-${filter.value ?? 'search'}`"
+            class="inline-flex items-center gap-2 bg-purple-500/10 border border-purple-400/40 text-sm px-3 py-1 rounded-full text-purple-100 hover:bg-purple-500/20 transition-colors"
+            @click="removeFilter(filter)"
+            type="button"
+          >
+            <span>{{ filter.label }}</span>
+            <span class="text-xs">&times;</span>
+          </button>
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 text-xs uppercase tracking-wide text-gray-400 hover:text-white"
+            @click="clearFilters"
+          >
+            Netejar filtres
+          </button>
+        </div>
+        <p v-else class="text-sm text-gray-500">Cap filtre actiu.</p>
+      </div>
+
       <div v-if="loading" class="text-center py-20">
         <p class="text-gray-400 text-lg">Carregant jocs...</p>
       </div>
 
-      <!-- Grid de juegos -->
-      <div v-else class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-        <GameCardMini v-for="game in games" :key="game.id" :id="game.id" :image="game.image" :name="game.name" :genre="game.genre" :year="game.year" :platform="game.platform" :reviews="game.reviews" />
-      </div>
+      <template v-else>
+        <div v-if="games.length" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+          <GameCardMini
+            v-for="game in games"
+            :key="game.id"
+            :id="game.id"
+            :image="game.image"
+            :name="game.name"
+            :genre="game.genre"
+            :year="game.year"
+            :platform="game.platform"
+            :average-rating="game.averageRating"
+            :review-count="game.reviewCount"
+          />
+        </div>
 
-      <!-- Mensaje si no hay juegos -->
-      <div v-if="!loading && games.length === 0" class="text-center py-20">
-        <p class="text-gray-400 text-lg">No s'han trobat jocs. Torna aviat!</p>
-      </div>
+        <div v-else class="text-center py-20">
+          <p class="text-gray-400 text-lg">No s'han trobat jocs. Torna aviat!</p>
+        </div>
+      </template>
     </div>
 
-    <!-- Footer -->
     <footer class="bg-gray-900 border-t border-gray-800 mt-20">
       <div class="max-w-7xl mx-auto px-4 py-12">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
@@ -164,19 +239,122 @@
         </div>
       </div>
     </footer>
+
+    <div v-if="filterPanelOpen" class="fixed inset-0 z-50 flex">
+      <div class="absolute inset-0 bg-black/60" @click="filterPanelOpen = false"></div>
+      <div class="relative z-10 ml-auto h-full w-full max-w-md bg-gray-900 border-l border-gray-800 shadow-2xl flex flex-col">
+        <div class="flex items-center justify-between px-6 py-4 border-b border-gray-800">
+          <div>
+            <p class="text-lg font-semibold">Filtres avançats</p>
+            <p class="text-sm text-gray-400">Refina la teva cerca per gèneres, plataformes i ordenació</p>
+          </div>
+          <button class="text-gray-400 hover:text-white" @click="filterPanelOpen = false" aria-label="Tancar filtres">
+            &times;
+          </button>
+        </div>
+        <div class="flex-1 overflow-y-auto px-6 py-6 space-y-6">
+          <div>
+            <p class="text-sm font-semibold text-gray-300 mb-2">Ordenar per</p>
+            <select
+              v-model="selectedSort"
+              @change="handleSortChange"
+              class="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+            >
+              <option v-for="option in sortOptions" :key="option.value" :value="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+          </div>
+
+          <div>
+            <p class="text-sm font-semibold text-gray-300 mb-3">Gèneres</p>
+            <div v-if="availableGenres.length" class="flex flex-wrap gap-2">
+              <label
+                v-for="genre in availableGenres"
+                :key="genre"
+                class="cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  class="sr-only"
+                  :value="genre"
+                  v-model="selectedGenres"
+                  @change="handleGenreChange"
+                />
+                <span
+                  class="inline-flex items-center px-3 py-1 rounded-full border text-sm transition-colors"
+                  :class="selectedGenres.includes(genre) ? 'bg-purple-600 border-purple-500 text-white' : 'border-gray-700 text-gray-300 hover:bg-gray-800'"
+                >
+                  {{ genre }}
+                </span>
+              </label>
+            </div>
+            <p v-else class="text-sm text-gray-500">Encara no hi ha gèneres disponibles.</p>
+          </div>
+
+          <div>
+            <p class="text-sm font-semibold text-gray-300 mb-3">Plataformes</p>
+            <div v-if="availablePlatforms.length" class="flex flex-wrap gap-2">
+              <label
+                v-for="platform in availablePlatforms"
+                :key="platform"
+                class="cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  class="sr-only"
+                  :value="platform"
+                  v-model="selectedPlatforms"
+                  @change="handlePlatformChange"
+                />
+                <span
+                  class="inline-flex items-center px-3 py-1 rounded-full border text-sm transition-colors"
+                  :class="selectedPlatforms.includes(platform) ? 'bg-purple-600 border-purple-500 text-white' : 'border-gray-700 text-gray-300 hover:bg-gray-800'"
+                >
+                  {{ platform }}
+                </span>
+              </label>
+            </div>
+            <p v-else class="text-sm text-gray-500">Encara no hi ha plataformes disponibles.</p>
+          </div>
+        </div>
+        <div class="border-t border-gray-800 px-6 py-4 flex items-center justify-between">
+          <button type="button" class="text-sm text-gray-400 hover:text-white" @click="clearFilters">
+            Netejar filtres
+          </button>
+          <button
+            type="button"
+            class="px-4 py-2 bg-purple-600 hover:bg-purple-500 rounded-lg text-sm font-semibold"
+            @click="filterPanelOpen = false"
+          >
+            Fet
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
-<script setup>
-import { ref, onMounted, computed, onBeforeUnmount } from 'vue'
-import { useRouter } from 'vue-router'
+<script setup lang="ts">
+import { ref, onMounted, computed, onBeforeUnmount, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import GameCardMini from '@/views/GameCardMini.vue'
-import { api } from '@/services/api'
+import { api, GameSummary } from '@/services/api'
 import { auth } from '@/services/auth'
 
 const router = useRouter()
+const route = useRoute()
 
-// ⭐ Estados de autenticación
+type SortOption = { value: 'best' | 'worst' | 'year' | 'reviews'; label: string }
+type ActiveFilter = { type: 'search' | 'genre' | 'platform'; label: string; value?: string }
+
+const sortOptions: SortOption[] = [
+  { value: 'best', label: 'Millor valorats primer' },
+  { value: 'worst', label: 'Pitjor valorats primer' },
+  { value: 'year', label: 'Any de llançament' },
+  { value: 'reviews', label: 'Nombre de ressenyes' }
+]
+
 const isLoggedIn = computed(() => !!auth.state.token && !!auth.state.user)
 const userName = computed(() => auth.state.user?.name || '')
 const userAvatar = computed(() => auth.state.user?.avatarUrl || '')
@@ -187,29 +365,44 @@ const userInitials = computed(() => {
   return names[0][0].toUpperCase()
 })
 
-// Estados del componente
-const games = ref([])
+type CatalogGame = {
+  id: string
+  image: string
+  name: string
+  genre: string
+  year: number
+  platform: string
+  averageRating: number
+  reviewCount: number
+}
+
+const games = ref<CatalogGame[]>([])
+const searchResults = ref<CatalogGame[]>([])
 const loading = ref(true)
 const searchQuery = ref('')
 const showSearchDropdown = ref(false)
 const showMenu = ref(false)
-const menuRef = ref(null)
+const menuRef = ref<HTMLElement | null>(null)
+const filterPanelOpen = ref(false)
 
-// Computed para filtrar juegos
-const filteredGames = computed(() => {
-  if (!searchQuery.value) return []
-  const query = searchQuery.value.toLowerCase()
-  return games.value.filter(game => 
-    game.name.toLowerCase().includes(query) ||
-    game.genre.toLowerCase().includes(query) ||
-    game.platform.toLowerCase().includes(query)
-  ).slice(0, 5)
+const availableGenres = ref<string[]>([])
+const availablePlatforms = ref<string[]>([])
+const selectedGenres = ref<string[]>([])
+const selectedPlatforms = ref<string[]>([])
+const selectedSort = ref<SortOption['value']>('best')
+
+const activeFilters = computed<ActiveFilter[]>(() => {
+  const chips: ActiveFilter[] = []
+  const trimmedSearch = searchQuery.value.trim()
+  if (trimmedSearch.length) {
+    chips.push({ type: 'search', label: `Cerca: ${trimmedSearch}` })
+  }
+  selectedGenres.value.forEach((genre) => chips.push({ type: 'genre', value: genre, label: `Gènere: ${genre}` }))
+  selectedPlatforms.value.forEach((platform) =>
+    chips.push({ type: 'platform', value: platform, label: `Plataforma: ${platform}` })
+  )
+  return chips
 })
-
-// Funciones
-const handleSearch = () => { showSearchDropdown.value = searchQuery.value.length > 0 }
-const hideDropdown = () => { setTimeout(() => { showSearchDropdown.value = false }, 200) }
-const closeDropdown = () => { showSearchDropdown.value = false; searchQuery.value = '' }
 
 const handleLogout = () => {
   auth.logout()
@@ -217,34 +410,166 @@ const handleLogout = () => {
   router.push('/login')
 }
 
-// Cerrar menú al hacer click fuera
-const handleClickOutside = (event) => {
-  if (menuRef.value && !menuRef.value.contains(event.target)) { showMenu.value = false }
+const handleClickOutside = (event: MouseEvent) => {
+  if (menuRef.value && !menuRef.value.contains(event.target as Node)) {
+    showMenu.value = false
+  }
 }
 
-// Cargar juegos al montar el componente
-onMounted(async () => {
+let searchDebounce: number | undefined
+const handleSearch = () => {
+  const query = searchQuery.value.trim()
+  showSearchDropdown.value = query.length > 0
+  if (searchDebounce) window.clearTimeout(searchDebounce)
+  if (!query) {
+    searchResults.value = []
+    return
+  }
+  searchDebounce = window.setTimeout(() => fetchSearchSuggestions(query), 250)
+}
+
+const hideDropdown = () => {
+  window.setTimeout(() => {
+    showSearchDropdown.value = false
+  }, 180)
+}
+
+const closeDropdown = () => {
+  showSearchDropdown.value = false
+}
+
+const parseListQuery = (value: unknown) => {
+  if (!value) return []
+  if (Array.isArray(value)) {
+    return Array.from(new Set(value.map((item) => (item ?? '').toString().trim()).filter(Boolean)))
+  }
+  if (typeof value === 'string') {
+    return Array.from(new Set(value.split(',').map((item) => item.trim()).filter(Boolean)))
+  }
+  return []
+}
+
+const mapGame = (game: GameSummary): CatalogGame => ({
+  id: game._id,
+  image: game.image,
+  name: game.name,
+  genre: game.genre,
+  year: Number(game.year),
+  platform: game.platform,
+  averageRating: Number.isFinite(game.averageRating) ? Number(game.averageRating) : 0,
+  reviewCount: Number(game.reviewCount ?? 0)
+})
+
+const fetchGames = async () => {
   try {
     loading.value = true
-    const data = await api.getGames()
-    games.value = data.map(g => ({
-      id: g._id,
-      image: g.image,
-      name: g.name,
-      genre: g.genre,
-      year: Number(g.year),
-      platform: g.platform,
-      reviews: g.reviews || []
-    }))
+    const data = await api.getGames({
+      q: searchQuery.value.trim() || undefined,
+      sort: selectedSort.value,
+      genres: selectedGenres.value,
+      platforms: selectedPlatforms.value,
+    })
+    games.value = data.items.map(mapGame)
+    availableGenres.value = data.availableGenres
+    availablePlatforms.value = data.availablePlatforms
   } catch (err) {
     console.error('Error carregant jocs del backend:', err)
   } finally {
     loading.value = false
   }
+}
+
+const fetchSearchSuggestions = async (term: string) => {
+  try {
+    const result = await api.getGames({ q: term, limit: 5 })
+    searchResults.value = result.items.map(mapGame)
+  } catch (error) {
+    console.error('Error cercant jocs:', error)
+    searchResults.value = []
+  }
+}
+
+const updateQuery = ({ page, resetPage }: { page?: number; resetPage?: boolean } = {}) => {
+  const trimmedSearch = searchQuery.value.trim()
+  const query: Record<string, string> = {
+    sort: selectedSort.value,
+  }
+  if (trimmedSearch) query.q = trimmedSearch
+  if (selectedGenres.value.length) query.genres = selectedGenres.value.join(',')
+  if (selectedPlatforms.value.length) query.platforms = selectedPlatforms.value.join(',')
+
+  router.replace({ path: route.path, query }).catch(() => {})
+}
+
+const handleSearchSubmit = () => {
+  updateQuery({ resetPage: true })
+}
+
+const handleSortChange = () => {
+  updateQuery({ resetPage: true })
+}
+
+const handleGenreChange = () => {
+  updateQuery({ resetPage: true })
+}
+
+const handlePlatformChange = () => {
+  updateQuery({ resetPage: true })
+}
+
+const removeFilter = (filter: ActiveFilter) => {
+  if (filter.type === 'search') {
+    searchQuery.value = ''
+    searchResults.value = []
+  }
+  if (filter.type === 'genre' && filter.value) {
+    selectedGenres.value = selectedGenres.value.filter((genre) => genre !== filter.value)
+  }
+  if (filter.type === 'platform' && filter.value) {
+    selectedPlatforms.value = selectedPlatforms.value.filter((platform) => platform !== filter.value)
+  }
+  updateQuery({ resetPage: true })
+}
+
+const clearFilters = () => {
+  const hasChanges =
+    selectedGenres.value.length || selectedPlatforms.value.length || selectedSort.value !== 'best'
+  selectedGenres.value = []
+  selectedPlatforms.value = []
+  selectedSort.value = 'best'
+  if (hasChanges) {
+    updateQuery({ resetPage: true })
+  }
+}
+
+const syncStateFromRoute = () => {
+  const { q, sort, genres, platforms, page } = route.query
+  searchQuery.value = typeof q === 'string' ? q : ''
+  const sortValue = typeof sort === 'string' && sortOptions.some((option) => option.value === sort) ? sort : 'best'
+  selectedSort.value = sortValue as SortOption['value']
+  selectedGenres.value = parseListQuery(genres)
+  selectedPlatforms.value = parseListQuery(platforms)
+  const parsedPage = Math.max(parseInt((page as string) ?? '1', 10) || 1, 1)
+  handleSearch()
+}
+
+watch(
+  () => ({ ...route.query }),
+  () => {
+    syncStateFromRoute()
+    fetchGames()
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
   document.addEventListener('click', handleClickOutside)
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('click', handleClickOutside)
+  if (searchDebounce) {
+    window.clearTimeout(searchDebounce)
+  }
 })
 </script>

--- a/frontend/src/views/GameCardMini.vue
+++ b/frontend/src/views/GameCardMini.vue
@@ -23,10 +23,10 @@
           </div>
           
           <!-- Rating con estrellas si hay reviews -->
-          <div v-if="reviews && reviews.length > 0" class="flex items-center gap-1">
+          <div v-if="reviewCount > 0" class="flex items-center gap-1">
             <span class="text-yellow-400">⭐</span>
-            <span class="text-sm font-semibold text-white">{{ averageRating }}</span>
-            <span class="text-xs text-gray-400">({{ reviews.length }})</span>
+            <span class="text-sm font-semibold text-white">{{ formattedRating }}</span>
+            <span class="text-xs text-gray-400">({{ reviewCount }})</span>
           </div>
           
           <div v-else class="text-xs text-gray-400">
@@ -41,9 +41,9 @@
       </div>
 
       <!-- Indicador de reviews siempre visible (arriba a la derecha) -->
-      <div v-if="reviews && reviews.length > 0" class="absolute top-2 right-2 bg-black/70 backdrop-blur-sm text-white text-xs font-bold px-2 py-1 rounded flex items-center gap-1">
+      <div v-if="reviewCount > 0" class="absolute top-2 right-2 bg-black/70 backdrop-blur-sm text-white text-xs font-bold px-2 py-1 rounded flex items-center gap-1">
         <span>⭐</span>
-        <span>{{ averageRating }}</span>
+        <span>{{ formattedRating }}</span>
       </div>
     </div>
 
@@ -64,15 +64,9 @@ const props = defineProps({
   genre: { type: String, default: '' },
   year: { type: [String, Number], default: '' },
   platform: { type: String, default: '' },
-  reviews: { type: Array, default: () => [] }
+  averageRating: { type: Number, default: 0 },
+  reviewCount: { type: Number, default: 0 }
 })
 
-// Calcular el rating promedio
-const averageRating = computed(() => {
-  if (!props.reviews || props.reviews.length === 0) return 0
-  
-  const sum = props.reviews.reduce((acc, review) => acc + (review.stars || 0), 0)
-  const avg = sum / props.reviews.length
-  return avg.toFixed(1)
-})
+const formattedRating = computed(() => (props.averageRating ?? 0).toFixed(1))
 </script>


### PR DESCRIPTION
Aquest PR implementa els filtres del catàleg al frontend:

- Nou panell de filtres (gèneres i plataformes) obert des de la icona al cercador.

Com provar-ho
1) Obrir /cataleg
2) Clicar la icona d’embut del cercador → s’obre el panell
3) Marcar/desmarcar gèneres/plataformes i comprovar que la llista es filtra
4) “Netejar filtres” restableix l’estat